### PR TITLE
修复四个问题

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '21'
+          node-version: '20'
 
       - name: Install dependencies
         run: |
@@ -22,11 +22,11 @@ jobs:
 
       - name: Build and package Electron app
         run: |
-          yarn make:electron
+          yarn build:electron
 
       - name: Upload Artifacts
         if: success()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: imstechauto
           path: |

--- a/core/src/course/processor/ExamProc.ts
+++ b/core/src/course/processor/ExamProc.ts
@@ -298,7 +298,7 @@ export default class ExamProc implements Processor {
 
     if (
       examScore &&
-      (examScore == this.#totalPoints || examScore > this.gtScorePass)
+      (examScore == this.#totalPoints || examScore > this.#totalPoints)
     )
       return null;
 

--- a/core/src/course/processor/OnlineVideoProc.ts
+++ b/core/src/course/processor/OnlineVideoProc.ts
@@ -154,8 +154,10 @@ export default class OnlineVideoProc implements Processor {
                           await page.reload({ timeout: 10000 });
                           await page.waitForLoadState('domcontentloaded');
                           //console.log("页面刷新完成");
+                          return checkVideoPlayStatusFunc();
                         } catch (reloadError) {
                           //console.log("页面刷新失败:", reloadError);
+                          return checkVideoPlayStatusFunc();
                         }
                       }
                     });
@@ -172,16 +174,19 @@ export default class OnlineVideoProc implements Processor {
                     })
                   } catch (clickError) {
                     //console.log("点击操作超时");
+                    return checkVideoPlayStatusFunc();
                   }
                 }
             }catch(e){
               //console.log("操作视频播放暂停失败:", e);
+              return checkVideoPlayStatusFunc();
             }
           }else{
             //继续检测
             //console.log("视频正在播放无需操作，继续检测");
-            checkVideoPlayStatusFunc();
+            return checkVideoPlayStatusFunc();
           }
+          checkVideoPlayStatusFunc();
         },10000)
       }catch(e){
         checkVideoPlayStatusFunc();

--- a/core/src/course/processor/OnlineVideoProc.ts
+++ b/core/src/course/processor/OnlineVideoProc.ts
@@ -14,8 +14,8 @@ import Config from '../../config.js';
 
 export default class OnlineVideoProc implements Processor {
   name: CourseType = 'online_video';
-
   async exec(page: Page) {
+    let checkVideoStatusTimer:any=null;
     const tryToShowControls = async () => {
       const playControls = page.locator('div.mvp-replay-player-all-controls');
       await playControls.evaluate(
@@ -103,10 +103,99 @@ export default class OnlineVideoProc implements Processor {
       this.timeStringToNumber(end),
     );
 
+    let onCur:any=0;
+    //检测视频是否卡住
+    const checkVideoPlayStatusFunc=()=>{
+      let saveCur=onCur;
+      try{
+        clearTimeout(checkVideoStatusTimer);
+        checkVideoStatusTimer = setTimeout(async function(){
+          if(saveCur==onCur)
+          {
+            //console.warn('Video playback may be stuck at:', saveCur);
+            let p = page.locator('.mvp-toggle-play.mvp-first-btn-margin');
+            //查找播放按钮元素，如果存在则目前为暂停状态，设置playStatus为false
+            let playStatus:any = false;
+            try {
+              playStatus = await page.evaluate(() => 
+                document.querySelector('.mvp-toggle-play.mvp-first-btn-margin i.mvp-fonts.mvp-fonts-play')
+              );
+            } catch (e) {
+              playStatus = true;
+            }
+            playStatus = !playStatus || playStatus == null ? true : false;
+            try{
+              if(playStatus==true)
+                {
+                  //console.log("目前为视频播放状态，执行暂停视频并重新开始播放");
+                  p = page.locator('.mvp-toggle-play.mvp-first-btn-margin');
+                  console.log(p);
+                  try {
+                    await page.evaluate(()=>{
+                      let btnC = document.querySelector('.mvp-toggle-play.mvp-first-btn-margin') as HTMLElement;
+                      if(btnC){
+                        btnC.click();
+                      }
+                    })
+                    await page.waitForTimeout(500);
+                    await page.evaluate(()=>{
+                      let btnC = document.querySelector('.mvp-toggle-play.mvp-first-btn-margin') as HTMLElement;
+                      if(btnC){
+                        btnC.click();
+                      }
+                    })
+                  } catch (clickError) {
+                    //console.log("点击操作超时，尝试重新定位元素");
+                    p = page.locator('.mvp-toggle-play.mvp-first-btn-margin');
+                    await p.click().catch(async () => {
+                      //console.log("重试点击也失败了，尝试刷新页面");
+                      if (page) {
+                        try {
+                          await page.reload({ timeout: 10000 });
+                          await page.waitForLoadState('domcontentloaded');
+                          //console.log("页面刷新完成");
+                        } catch (reloadError) {
+                          //console.log("页面刷新失败:", reloadError);
+                        }
+                      }
+                    });
+                  }
+                }else{
+                  p = page.locator('.mvp-toggle-play.mvp-first-btn-margin');
+                  //console.log("目前为视频暂停状态，点击开始播放");
+                  try {
+                    await page.evaluate(()=>{
+                      let btnC = document.querySelector('.mvp-toggle-play.mvp-first-btn-margin') as HTMLElement;
+                      if(btnC){
+                        btnC.click();
+                      }
+                    })
+                  } catch (clickError) {
+                    //console.log("点击操作超时");
+                  }
+                }
+            }catch(e){
+              //console.log("操作视频播放暂停失败:", e);
+            }
+          }else{
+            //继续检测
+            //console.log("视频正在播放无需操作，继续检测");
+            checkVideoPlayStatusFunc();
+          }
+        },10000)
+      }catch(e){
+        checkVideoPlayStatusFunc();
+      }
+      
+    }
+    //执行视频播放状态检测
+    checkVideoPlayStatusFunc();
+
     let preCur = (await getMeidaTime())[0];
 
     const updatePrcsBar = async () => {
       const cur = (await getMeidaTime())[0];
+      onCur=cur;
       if (preCur != cur) {
         prcsBar.tick(
           this.timeStringToNumber(cur) - this.timeStringToNumber(preCur),
@@ -147,6 +236,7 @@ export default class OnlineVideoProc implements Processor {
     );
 
     clearInterval(timer);
+    clearTimeout(checkVideoStatusTimer); //删除视频播放状态检测计时器
     updatePrcsBar();
   }
 

--- a/core/src/course/search.ts
+++ b/core/src/course/search.ts
@@ -126,18 +126,19 @@ async function getUncompletedCourses(
       return (
         await Promise.all(
           activityLocList.map(async (activityLoc) =>
-            
             (await hasContentActivity(activityLoc))
-              ? (await getActivityName(activityLoc)=='' ? [] : {
-                moduleId: syllabus.moduleId,
-                moduleName: syllabus.moduleName,
-                syllabusId: syllabus.syllabusId,
-                syllabusName: syllabus.syllabusName,
-                type: await getActivityType(activityLoc),
-                activityId: await getActivityId(activityLoc),
-                activityName: await getActivityName(activityLoc),
-                activityLoc,
-              })
+              ? (await getActivityName(activityLoc)) == ''
+                ? []
+                : {
+                    moduleId: syllabus.moduleId,
+                    moduleName: syllabus.moduleName,
+                    syllabusId: syllabus.syllabusId,
+                    syllabusName: syllabus.syllabusName,
+                    type: await getActivityType(activityLoc),
+                    activityId: await getActivityId(activityLoc),
+                    activityName: await getActivityName(activityLoc),
+                    activityLoc,
+                  }
               : [],
           ),
         )
@@ -176,7 +177,7 @@ async function getUncompletedCourses(
 }
 
 async function getActivityName(activity: Locator) {
-  try{
+  try {
     const titleElt = activity.locator('div.activity-title a.title');
     const title = await titleElt.evaluate((e) => {
       return e.textContent;
@@ -186,7 +187,7 @@ async function getActivityName(activity: Locator) {
       return '';
     }
     return title;
-  }catch(e){
+  } catch (e) {
     return '';
   }
 }

--- a/core/src/course/search.ts
+++ b/core/src/course/search.ts
@@ -126,17 +126,18 @@ async function getUncompletedCourses(
       return (
         await Promise.all(
           activityLocList.map(async (activityLoc) =>
+            
             (await hasContentActivity(activityLoc))
-              ? {
-                  moduleId: syllabus.moduleId,
-                  moduleName: syllabus.moduleName,
-                  syllabusId: syllabus.syllabusId,
-                  syllabusName: syllabus.syllabusName,
-                  type: await getActivityType(activityLoc),
-                  activityId: await getActivityId(activityLoc),
-                  activityName: await getActivityName(activityLoc),
-                  activityLoc,
-                }
+              ? (await getActivityName(activityLoc)=='' ? [] : {
+                moduleId: syllabus.moduleId,
+                moduleName: syllabus.moduleName,
+                syllabusId: syllabus.syllabusId,
+                syllabusName: syllabus.syllabusName,
+                type: await getActivityType(activityLoc),
+                activityId: await getActivityId(activityLoc),
+                activityName: await getActivityName(activityLoc),
+                activityLoc,
+              })
               : [],
           ),
         )
@@ -175,13 +176,19 @@ async function getUncompletedCourses(
 }
 
 async function getActivityName(activity: Locator) {
-  const titleElt = activity.locator('div.activity-title a.title');
-  const title = await titleElt.textContent();
-  if (!title) {
-    console.log(activity);
-    throw 'course title is undefined';
+  try{
+    const titleElt = activity.locator('div.activity-title a.title');
+    const title = await titleElt.evaluate((e) => {
+      return e.textContent;
+    });
+    if (!title) {
+      console.log(activity);
+      return '';
+    }
+    return title;
+  }catch(e){
+    return '';
   }
-  return title;
 }
 
 async function getActivityType(activity: Locator): Promise<CourseType> {

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -147,9 +147,9 @@ async function init(page: Page) {
         }
 
         // 从这里开始添加随机延迟
-        try{
+        try {
           await withRandomDelay(page, () => t.click());
-        }catch(e){
+        } catch (e) {
           /**
            * 这里必须跳过
            * 因为第二次打开脚本后
@@ -166,12 +166,7 @@ async function init(page: Page) {
             waitUntil: 'domcontentloaded',
           }),
         );
-        
-          
-        
-        
-        
-        
+
         for (let count = 5; count > -1; count--) {
           await withRandomDelay(page, () => waitForSPALoaded(page));
           try {
@@ -185,8 +180,6 @@ async function init(page: Page) {
             );
           }
         }
-          
-        
 
         // 回到课程选择页
         await withRandomDelay(page, () =>

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -130,7 +130,6 @@ async function init(page: Page) {
         if (course.syllabusId) {
           tLoc = tLoc.locator(`#${course.syllabusId}`);
         }
-
         const t = tLoc
           .locator(`#learning-activity-${course.activityId}`)
           .getByText(course.activityName, { exact: true });
@@ -148,15 +147,31 @@ async function init(page: Page) {
         }
 
         // 从这里开始添加随机延迟
-        await withRandomDelay(page, () => t.click());
-
+        try{
+          await withRandomDelay(page, () => t.click());
+        }catch(e){
+          /**
+           * 这里必须跳过
+           * 因为第二次打开脚本后
+           * 学习网会默认勾选只显示未学内容
+           * 但已经完成的自测考试依然会来到这里执行点击操作
+           * 此时网页内自测考试已经被隐藏，导致寻找不到元素后整个脚本崩溃
+           */
+          //console.log("无法进入该课程，该课程可能已经完成学习。跳过");
+          continue;
+        }
         await withRandomDelay(page, () =>
           page.waitForURL(RegExp(`^${Config.urls.course()}.*`), {
             timeout: 30000,
             waitUntil: 'domcontentloaded',
           }),
         );
-
+        
+          
+        
+        
+        
+        
         for (let count = 5; count > -1; count--) {
           await withRandomDelay(page, () => waitForSPALoaded(page));
           try {
@@ -170,6 +185,8 @@ async function init(page: Page) {
             );
           }
         }
+          
+        
 
         // 回到课程选择页
         await withRandomDelay(page, () =>

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,5 +55,5 @@ async function connectToElectron() {
 app.whenReady().then(createWindow);
 
 app.on('window-all-closed', () => {
-    app.quit();
+  app.quit();
 });


### PR DESCRIPTION
1.当脚本再次打开时访问之前已经学习到一半的课程，遇到已经及格的自测考试后，脚本依然会获取到并尝试进行Click操作，这会导致整个脚本崩溃结束，因为此时的自测考试已经被当作已经学习的内容从网页中隐藏掉了。**目前针对该问题在Click操作外增加了Try来捕获异常，执行失败后跳过该课程项目继续执行。**

2.在学习音视频课程时，视频会偶尔播放几分钟后卡在加载中无法继续，**目前针对该问题添加了checkVideoPlayStatusFunc对视频播放进度循环检测，如果视频持续卡在某个时间节点>=10s，脚本则会主动暂停并重新点击播放来恢复视频播放状态解决卡在加载中的问题。**

3.在旧版本中尝试脚本遇到超过600个子课程的课程时，就会无法获取提示执行超时，从而导致课程异常，**目前更改了getActivityName方法的实现以及activitiesAsync方法来保证至少能获取到90%以上的课程并学习**。 

4.在旧版本中进行考试分数获取时，旧版本对于是否需要重新测验的分数判断逻辑有误，**目前已修复为只要历史分数大于或等于env配置分数则无需再次答题**。

![微信截图_20250607192945](https://github.com/user-attachments/assets/5f4aa644-7b93-467d-b419-c86f45d48ad2)