### PR TITLE
改进1个问题

### DIFF
--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -84,6 +84,8 @@ async function init(page: Page) {
         courses = (await Search.getUncompletedCourses(page, item)).filter(
           (course) => course.progress != 'full' || course.type == 'exam',
         );
+        // 使“未完成”取消勾选，防止已完成测试阻塞执行
+        await page.locator('input[type="checkbox"]').setChecked(false);
       } catch (e) {
         console.log(`[${item.title}]课程异常，跳过`);
         if (num == 0) {


### PR DESCRIPTION
1.
在脚本再次打开已完成测试时，因为勾选“未完成”将导致脚本点击活动超时失败，为此该 pr 将在获取课程列表后取消勾选“未完成”